### PR TITLE
Remove border around site with border-box

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,11 @@
+*,
+*:after,
+*:before {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
 :root {
 	--teal: #47e5bb;
 	--purple: #7d61f9;


### PR DESCRIPTION
I added the following code to the CSS file to remove the default border from around the site:
```css
*,
*:after,
*:before {
  box-sizing: border-box;
  margin: 0;
  padding: 0;
}
```

I tested the site in Chrome, Safari, and FireFox.